### PR TITLE
Lexer rewrite

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,17 @@
+## Lexing
+- ~~Literals~~
+- ~~Identifiers~~
+- ~~Keywords~~
+- ~~Punctuation~~
+- ~~Comments~~
+- ~~Preprocessor directives~~
+- ~~Illegals~~
+
 ## Parsing
+### custom parser
+TODO: Implement
+
+### chumsky parser
 - ~~Version directive~~
 - ~~Extension directive~~
 - ~~Line directive~~

--- a/docs/grammar.bnf
+++ b/docs/grammar.bnf
@@ -1,0 +1,41 @@
+
+# Identifiers/Keywords/Built-in types/Structs
+<word> ::= <ident_start> <ident_char>*
+
+<ident_start> ::= [a-z] | [A-Z] | "_"
+<ident_char> ::= [a-z] | [A-Z] | "_" | <digit>
+
+
+# Literals
+<lit> ::= "true" | "false" | <number>
+<number> ::= <uint> | <int> | <f64> | <f32>
+
+# Floating points
+<f64> ::= <float> "lf" | <float> "LF"
+<f32> ::= <float> "f" | <float> "F"
+
+<float> ::= <float_e> | <float_dot>
+
+<float_e> ::= <float_dot> <exp> <sign>? <digit>+
+<sign> ::= "+" | "-"
+<exp> ::= "e" | "E"
+
+<float_dot> ::= <float_3> | <float_2> | <float_1>
+<float_3> ::= <digit>+ "." <digit>+
+<float_2> ::= <digit>+ "."
+<float_1> ::= "." <digit>+
+
+# Integers
+<uint> ::= <hex> <u_suffix> | <oct> <u_suffix> | <dec> <u_suffix>
+<u_suffix> ::= "u" | "U"
+<int> ::= <hex> | <oct> | <dec>
+
+<dec> ::= "0" | <dec_digit> <digit>*
+<hex> ::= "0x" <hex_digit>+
+<oct> ::= "0" <oct_digit>+
+
+<hex_digit> ::= <digit> | "a" | "b" | "c" | "d" | "e" | "f" | "A" | "B" | "C" | "D" | "E" | "F"
+<oct_digit> ::= [0-7]
+<dec_digit> ::= [1-9]
+
+<digit> ::= [0-9]

--- a/docs/grammar.bnf
+++ b/docs/grammar.bnf
@@ -12,7 +12,7 @@
 
 # Floating points
 <f64> ::= <float> "lf" | <float> "LF"
-<f32> ::= <float> "f" | <float> "F"
+<f32> ::= <float> "f" | <float> "F" | <float>
 
 <float> ::= <float_e> | <float_dot>
 

--- a/docs/grammar.bnf
+++ b/docs/grammar.bnf
@@ -1,41 +1,40 @@
+## Identifiers/Keywords/Built-in types/Structs
+word ::= ident_start ident_char*
 
-# Identifiers/Keywords/Built-in types/Structs
-<word> ::= <ident_start> <ident_char>*
-
-<ident_start> ::= [a-z] | [A-Z] | "_"
-<ident_char> ::= [a-z] | [A-Z] | "_" | <digit>
+ident_start ::= [a-z] | [A-Z] | "_"
+ident_char ::= [a-z] | [A-Z] | "_" | digit
 
 
-# Literals
-<lit> ::= "true" | "false" | <number>
-<number> ::= <uint> | <int> | <f64> | <f32>
+## Literals
+lit ::= "true" | "false" | number
+number ::= uint | int | f64 | f32
 
 # Floating points
-<f64> ::= <float> "lf" | <float> "LF"
-<f32> ::= <float> "f" | <float> "F" | <float>
+f64 ::= float "lf" | float "LF"
+f32 ::= float "f" | float "F" | float
 
-<float> ::= <float_e> | <float_dot>
+float ::= float_e | float_dot
 
-<float_e> ::= <float_dot> <exp> <sign>? <digit>+
-<sign> ::= "+" | "-"
-<exp> ::= "e" | "E"
+float_e ::= float_dot exp sign? digit+
+sign ::= "+" | "-"
+exp ::= "e" | "E"
 
-<float_dot> ::= <float_3> | <float_2> | <float_1>
-<float_3> ::= <digit>+ "." <digit>+
-<float_2> ::= <digit>+ "."
-<float_1> ::= "." <digit>+
+float_dot ::= float_3 | float_2 | float_1
+float_3 ::= digit+ "." digit+
+float_2 ::= digit+ "."
+float_1 ::= "." digit+
 
 # Integers
-<uint> ::= <hex> <u_suffix> | <oct> <u_suffix> | <dec> <u_suffix>
-<u_suffix> ::= "u" | "U"
-<int> ::= <hex> | <oct> | <dec>
+uint ::= hex u_suffix | oct u_suffix | dec u_suffix
+u_suffix ::= "u" | "U"
+int ::= hex | oct | dec
 
-<dec> ::= "0" | <dec_digit> <digit>*
-<hex> ::= "0x" <hex_digit>+
-<oct> ::= "0" <oct_digit>+
+dec ::= "0" | dec_digit digit*
+hex ::= "0x" hex_digit+
+oct ::= "0" oct_digit+
 
-<hex_digit> ::= <digit> | "a" | "b" | "c" | "d" | "e" | "f" | "A" | "B" | "C" | "D" | "E" | "F"
-<oct_digit> ::= [0-7]
-<dec_digit> ::= [1-9]
+hex_digit ::= digit | "a" | "b" | "c" | "d" | "e" | "f" | "A" | "B" | "C" | "D" | "E" | "F"
+oct_digit ::= [0-7]
+dec_digit ::= [1-9]
 
-<digit> ::= [0-9]
+digit ::= [0-9]

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4,9 +4,6 @@ Missing/incomplete:
 - Samplers
 - Images
 - Atomic counters
-- `f` number suffix
-- `.n` float notation (skipping before dot)
-- `n.` float notation (skipping after dot)
 - Arrays/opaque arrays limitations
 - Subroutines
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -56,6 +56,16 @@ Any integer types can be implicitly converted to a float. Integer types and floa
 
 Vectors and matrices can be converted if the type they're built-on can be implicitly converted.
 
+# Identifiers
+Identifiers can contain any of the following characters:
+```glsl
+a-z // lowercase latin
+A-Z // uppercase latin
+0-9 // digits
+_   // underscore
+```
+An identifier cannot start with a digit. Identifiers starting with the `gl_` prefix are reserved for OpenGL. Identifiers also cannot be any of the keywords, reserved keywords, or built-in type identifiers.
+
 # Literals
 These are the allowed literals:
 - `bool` - `true` and `false`,
@@ -64,24 +74,10 @@ These are the allowed literals:
 - `float` - `1.0` (`1e10` or `1.2e10` for exponential notation, which is always base-10),
 - `double` - `1.0lf` or `1.0LF` (mixing case such as `lF` is not allowed).
 
+Integers use *32-bit* precision. Floats are *single-precision* and doubles are *double-precision* IEEE floating point numbers.
+
 ### Numbers
-The following notations are valid:
-```glsl
-0
-{1..9}{0..9}+
-
-0{0..7}+
-
-0x{0..F}+
-
-1.0
-1.0{e|E}5
-1{e|E}5
-
-1.0{lf|LF}
-1.0{e|E}5{lf|LF}
-1{e|E}5{lf|LF}
-```
+For a specification of valid number notations, see the [grammar](./grammar.bnf) file.
 
 ### Operators
 Mathematical operators:
@@ -159,10 +155,6 @@ a ^^ b // Logical XOR
 
 # Variables
 Variables cannot be of the `void` type. This applies to any variable type, local, global, etc.
-
-Variable identifiers:
-- cannot be the same as a type identifier.
-- cannot start with the `gl_` prefix; note that `gl` or even just `g` is allowed. (The exception is some built-in variables).
 
 ## Initialization
 Variables can be initialized at the site of declaration:
@@ -536,14 +528,70 @@ for ({VAR_DECL}; {COND_EXPR}; {INC_EXPR}) {
 
 All 3 statements are optional, i.e. `(;;)` is a valid (infinite) loop.
 
+# Comments
+Comment syntax:
+```glsl
+// Comment which goes to the end-of-line
+
+/* Comment between these delimiters */
+```
+
+Delimited comments cannot be nested, i.e. the following produces an error:
+```glsl
+/* First comment
+    /* inner comment */ (<- First comment ends here)
+*/ (<- Unmatched delimiter/punctuation)
+```
+
+Single line comments can continue with the *line-continuation character* `\`, in which case the comment extends to the EOL of the next line. So the following is one single comment:
+```glsl
+// First comment... \
+int i = 5; // This is still part of the first comment
+```
+
+Open-ended multiline comments containing the EOF produce an error:
+```glsl
+// Something else
+
+/*
+<EOF>
+```
+Note that single-line comments, even with the `\` continuation character, can never produce this error even if they also are at the end of the file.
+
+### Line-continuation character
+```glsl
+<anything but \>\<EOL>
+
+// Valid:
+keyword\
+190\
+ident_\
++\
+
+// Invalid:
+anything\\ // The first \ escapes the second \
+```
+
 # Preprocessor
 
 ## Directives
 All preprocessor directives follow the syntax:
 ```glsl
-#/*...*/
+#Directive ...
+
+   #Directive ...
+
+#    Directive ...
+
+#Directive ... \
+    Directive continues here
+
+// This is ignored:
+#
 ```
-The `#` symbol must be the first (aside from whitespace) and the statement ends at EOL.
+The `#` symbol must be the first (aside from whitespace) and the statement ends at EOL, unless a [Line-Continuation Character](#line-continuation-character) is present. The `#` can be followed by whitespace before the first directive letter.
+
+A `#` on its own without anything after is ignored.
 
 ### Version
 The version directive is specified like so:

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -333,6 +333,10 @@ impl Lit {
 				if let Ok(f) = s.parse::<f64>() {
 					return Ok(Self::Double(f));
 				}
+			} else if suffix == "f" || suffix == "F" {
+				if let Ok(f) = s.parse::<f32>() {
+					return Ok(Self::Float(f));
+				}
 			} else {
 				return Err(());
 			}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,4 +1,4 @@
-use crate::parser::{NumType, OpType};
+use crate::lexer::{NumType, OpType};
 
 /// Holds either one or the other value.
 #[derive(Debug, Clone)]
@@ -256,27 +256,31 @@ impl std::fmt::Display for Lit {
 }
 
 impl Lit {
-	pub fn parse_num(s: &str, type_: NumType) -> Result<Self, ()> {
-		// Sanity check, but this should never fail.
+	pub fn parse_num(
+		s: &str,
+		suffix: Option<&str>,
+		type_: NumType,
+	) -> Result<Self, ()> {
+		// This can be empty, e.g. `0xu` is a `NumType::Hex` with contents `` with suffix `u`.
 		if s == "" {
 			return Err(());
 		}
 		match type_ {
-			NumType::Normal => Self::parse_num_dec(s),
-			NumType::Hex => Self::parse_num_hex(s),
-			NumType::Oct => Self::parse_num_oct(s),
-			NumType::Float => Self::parse_num_float(s),
-			NumType::Double => Self::parse_num_double(s),
+			NumType::Dec => Self::parse_num_dec(s, suffix),
+			NumType::Hex => Self::parse_num_hex(s, suffix),
+			NumType::Oct => Self::parse_num_oct(s, suffix),
+			NumType::Float => Self::parse_num_float(s, suffix),
 		}
 	}
 
-	fn parse_num_dec(s: &str) -> Result<Self, ()> {
-		let last = s.chars().last().unwrap();
-		if last == 'u' || last == 'U' {
-			// Remove the 'u' suffix.
-			let s = &s[..s.len() - 1];
-			if let Ok(u) = u64::from_str_radix(s, 10) {
-				return Ok(Self::UInt(u));
+	fn parse_num_dec(s: &str, suffix: Option<&str>) -> Result<Self, ()> {
+		if let Some(suffix) = suffix {
+			if suffix == "u" || suffix == "U" {
+				if let Ok(u) = u64::from_str_radix(s, 10) {
+					return Ok(Self::UInt(u));
+				}
+			} else {
+				return Err(());
 			}
 		} else {
 			if let Ok(i) = i64::from_str_radix(s, 10) {
@@ -287,16 +291,14 @@ impl Lit {
 		Err(())
 	}
 
-	fn parse_num_hex(s: &str) -> Result<Self, ()> {
-		// Trim the '0x' part, otherwise the conversion will fail.
-		let s = s.trim_start_matches("0x");
-
-		let last = s.chars().last().unwrap();
-		if last == 'u' || last == 'U' {
-			// Remove the 'u' suffix.
-			let s = &s[..s.len() - 1];
-			if let Ok(u) = u64::from_str_radix(s, 16) {
-				return Ok(Self::UInt(u));
+	fn parse_num_hex(s: &str, suffix: Option<&str>) -> Result<Self, ()> {
+		if let Some(suffix) = suffix {
+			if suffix == "u" || suffix == "U" {
+				if let Ok(u) = u64::from_str_radix(s, 16) {
+					return Ok(Self::UInt(u));
+				}
+			} else {
+				return Err(());
 			}
 		} else {
 			if let Ok(i) = i64::from_str_radix(s, 16) {
@@ -307,16 +309,14 @@ impl Lit {
 		Err(())
 	}
 
-	fn parse_num_oct(s: &str) -> Result<Self, ()> {
-		// Trim the '0' part, because the first '0' is not part of the number itself but rather the radix.
-		let s = s.trim_start_matches("0");
-
-		let last = s.chars().last().unwrap();
-		if last == 'u' || last == 'U' {
-			// Remove the 'u' suffix.
-			let s = &s[..s.len() - 1];
-			if let Ok(u) = u64::from_str_radix(s, 8) {
-				return Ok(Self::UInt(u));
+	fn parse_num_oct(s: &str, suffix: Option<&str>) -> Result<Self, ()> {
+		if let Some(suffix) = suffix {
+			if suffix == "u" || suffix == "U" {
+				if let Ok(u) = u64::from_str_radix(s, 8) {
+					return Ok(Self::UInt(u));
+				}
+			} else {
+				return Err(());
 			}
 		} else {
 			if let Ok(i) = i64::from_str_radix(s, 8) {
@@ -327,20 +327,19 @@ impl Lit {
 		Err(())
 	}
 
-	fn parse_num_float(s: &str) -> Result<Self, ()> {
-		if let Ok(f) = s.parse::<f32>() {
-			return Ok(Self::Float(f));
-		}
-
-		Err(())
-	}
-
-	fn parse_num_double(s: &str) -> Result<Self, ()> {
-		// Remove the 'lf' suffix.
-		let s = &s[..s.len() - 2];
-
-		if let Ok(f) = s.parse::<f64>() {
-			return Ok(Self::Double(f));
+	fn parse_num_float(s: &str, suffix: Option<&str>) -> Result<Self, ()> {
+		if let Some(suffix) = suffix {
+			if suffix == "lf" || suffix == "LF" {
+				if let Ok(f) = s.parse::<f64>() {
+					return Ok(Self::Double(f));
+				}
+			} else {
+				return Err(());
+			}
+		} else {
+			if let Ok(f) = s.parse::<f32>() {
+				return Ok(Self::Float(f));
+			}
 		}
 
 		Err(())

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -713,10 +713,13 @@ fn identifiers() {
 	assert_tokens!("ident", Token::Ident("ident".into()));
 	assert_tokens!("gl_something", Token::Ident("gl_something".into()));
 	assert_tokens!("id_145", Token::Ident("id_145".into()));
+	assert_tokens!("_9ga", Token::Ident("_9ga".into()));
 }
 
 #[test]
 fn keywords() {
+	assert_tokens!("true", Token::Bool(true));
+	assert_tokens!("false", Token::Bool(false));
 	assert_tokens!("if", Token::If);
 	assert_tokens!("else", Token::Else);
 	assert_tokens!("for", Token::For);
@@ -803,7 +806,115 @@ fn punctuation() {
 }
 
 #[test]
-fn literals() {
-	assert_tokens!("true", Token::Bool(true));
-	assert_tokens!("false", Token::Bool(false));
+#[rustfmt::skip]
+fn integers(){
+	// Zero
+	assert_tokens!("0", Token::Num{num: "0".into(), suffix: None, type_: NumType::Dec});
+	// Zero with suffix
+	assert_tokens!("0u", Token::Num{num: "0".into(), suffix: Some("u".into()), type_: NumType::Dec});
+	// Decimal
+	assert_tokens!("1", Token::Num{num: "1".into(), suffix: None, type_: NumType::Dec});
+	assert_tokens!("123456", Token::Num{num: "123456".into(), suffix: None, type_: NumType::Dec});
+	assert_tokens!("100008", Token::Num{num: "100008".into(), suffix: None,  type_: NumType::Dec});
+	// Decimal with suffix
+	assert_tokens!("1u", Token::Num{num: "1".into(), suffix: Some("u".into()), type_: NumType::Dec});
+	assert_tokens!("123456u", Token::Num{num: "123456".into(), suffix: Some("u".into()), type_: NumType::Dec});
+	assert_tokens!("100008u", Token::Num{num: "100008".into(), suffix: Some("u".into()),  type_: NumType::Dec});
+	// Octal
+	assert_tokens!("00", Token::Num{num: "0".into(), suffix: None,  type_: NumType::Oct});
+	assert_tokens!("01715", Token::Num{num: "1715".into(), suffix: None,  type_: NumType::Oct});
+	assert_tokens!("09183", Token::Num{num: "9183".into(), suffix: None, type_: NumType::Oct});
+	// Octal with suffix
+	assert_tokens!("00u", Token::Num{num: "0".into(), suffix: Some("u".into()),  type_: NumType::Oct});
+	assert_tokens!("01715u", Token::Num{num: "1715".into(), suffix: Some("u".into()),  type_: NumType::Oct});
+	assert_tokens!("09183u", Token::Num{num: "9183".into(), suffix: Some("u".into()), type_: NumType::Oct});
+	// Hexadecimal
+	assert_tokens!("0x", Token::Num{num: "".into(), suffix: None, type_: NumType::Hex});
+	assert_tokens!("0x91fa", Token::Num{num: "91fa".into(), suffix: None,  type_: NumType::Hex});
+	assert_tokens!("0x00F", Token::Num{num: "00F".into(), suffix: None,  type_: NumType::Hex});
+	// Hexadecimal with suffix
+	assert_tokens!("0xu", Token::Num{num: "".into(), suffix: Some("u".into()), type_: NumType::Hex});
+	assert_tokens!("0x91fau", Token::Num{num: "91fa".into(), suffix: Some("u".into()),  type_: NumType::Hex});
+	assert_tokens!("0x00Fu", Token::Num{num: "00F".into(), suffix: Some("u".into()),  type_: NumType::Hex});
+}
+
+#[test]
+#[rustfmt::skip]
+fn floats() {
+	// Zeroes
+	assert_tokens!("0.0", Token::Num{num: "0.0".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("0.", Token::Num{num: "0.".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!(".0", Token::Num{num: ".0".into(), suffix: None, type_: NumType::Float});
+	// Zeroes with suffix
+	assert_tokens!("0.0lf", Token::Num{num: "0.0".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("0.lf", Token::Num{num: "0.".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!(".0lf", Token::Num{num: ".0".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	// Zeroes with exponent
+	assert_tokens!("0e7", Token::Num{num: "0e7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("0e+7", Token::Num{num: "0e+7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("0e-7", Token::Num{num: "0e-7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("0.0e7", Token::Num{num: "0.0e7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("0.0e+7", Token::Num{num: "0.0e+7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("0.0e-7", Token::Num{num: "0.0e-7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("0.e7", Token::Num{num: "0.e7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("0.e+7", Token::Num{num: "0.e+7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("0.e-7", Token::Num{num: "0.e-7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!(".0e7", Token::Num{num: ".0e7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!(".0e+7", Token::Num{num: ".0e+7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!(".0e-7", Token::Num{num: ".0e-7".into(), suffix: None, type_: NumType::Float});
+	// Zeroes with exponent and suffix
+	assert_tokens!("0e7lf", Token::Num{num: "0e7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("0e+7lf", Token::Num{num: "0e+7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("0e-7lf", Token::Num{num: "0e-7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("0.0e7lf", Token::Num{num: "0.0e7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("0.0e+7lf", Token::Num{num: "0.0e+7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("0.0e-7lf", Token::Num{num: "0.0e-7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("0.e7lf", Token::Num{num: "0.e7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("0.e+7lf", Token::Num{num: "0.e+7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("0.e-7lf", Token::Num{num: "0.e-7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!(".0e7lf", Token::Num{num: ".0e7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!(".0e+7lf", Token::Num{num: ".0e+7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!(".0e-7lf", Token::Num{num: ".0e-7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	// Digits
+	assert_tokens!("1.0", Token::Num{num: "1.0".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("1.1", Token::Num{num: "1.1".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("1.", Token::Num{num: "1.".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!(".1", Token::Num{num: ".1".into(), suffix: None, type_: NumType::Float});
+	// Digits with suffix
+	assert_tokens!("1.0lf", Token::Num{num: "1.0".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("1.1lf", Token::Num{num: "1.1".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("1.lf", Token::Num{num: "1.".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!(".1lf", Token::Num{num: ".1".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	// Digits with exponent
+	assert_tokens!("1e7", Token::Num{num: "1e7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("1e+7", Token::Num{num: "1e+7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("1e-7", Token::Num{num: "1e-7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("1.0e7", Token::Num{num: "1.0e7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("1.0e+7", Token::Num{num: "1.0e+7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("1.0e-7", Token::Num{num: "1.0e-7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("1.1e7", Token::Num{num: "1.1e7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("1.1e+7", Token::Num{num: "1.1e+7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("1.1e-7", Token::Num{num: "1.1e-7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("1.e7", Token::Num{num: "1.e7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("1.e+7", Token::Num{num: "1.e+7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!("1.e-7", Token::Num{num: "1.e-7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!(".1e7", Token::Num{num: ".1e7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!(".1e+7", Token::Num{num: ".1e+7".into(), suffix: None, type_: NumType::Float});
+	assert_tokens!(".1e-7", Token::Num{num: ".1e-7".into(), suffix: None, type_: NumType::Float});
+	// Digits with exponent and suffix
+	assert_tokens!("1e7lf", Token::Num{num: "1e7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("1e+7lf", Token::Num{num: "1e+7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("1e-7lf", Token::Num{num: "1e-7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("1.0e7lf", Token::Num{num: "1.0e7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("1.0e+7lf", Token::Num{num: "1.0e+7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("1.0e-7lf", Token::Num{num: "1.0e-7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("1.1e7lf", Token::Num{num: "1.1e7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("1.1e+7lf", Token::Num{num: "1.1e+7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("1.1e-7lf", Token::Num{num: "1.1e-7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("1.e7lf", Token::Num{num: "1.e7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("1.e+7lf", Token::Num{num: "1.e+7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!("1.e-7lf", Token::Num{num: "1.e-7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!(".1e7lf", Token::Num{num: ".1e7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!(".1e+7lf", Token::Num{num: ".1e+7".into(), suffix: Some("lf".into()), type_: NumType::Float});
+	assert_tokens!(".1e-7lf", Token::Num{num: ".1e-7".into(), suffix: Some("lf".into()), type_: NumType::Float});
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -924,6 +924,25 @@ fn punctuation() {
 
 #[test]
 #[rustfmt::skip]
+fn comments() {
+	// Line comments
+	assert_tokens!("// a comment", Token::Comment{str: " a comment".into(), contains_eof: false});
+	assert_tokens!("//a comment", Token::Comment{str: "a comment".into(), contains_eof: false});
+	assert_tokens!("//a comment \\", Token::Comment{str: "a comment ".into(), contains_eof: false});
+	assert_tokens!("//a comment \\\\", Token::Comment{str: "a comment \\\\".into(), contains_eof: false});
+	assert_tokens!("//a comment \\n", Token::Comment{str: "a comment \\n".into(), contains_eof: false});
+	assert_tokens!("//a comment \\\r\n continuation", Token::Comment{str: "a comment \r\n continuation".into(), contains_eof: false});
+	assert_tokens!("// a comment \\\r continuation", Token::Comment{str: " a comment \r continuation".into(), contains_eof: false});
+	assert_tokens!("//a comment\\\ncontinuation", Token::Comment{str: "a comment\ncontinuation".into(), contains_eof: false});
+	// Multi-line comments
+	assert_tokens!("/* a comment */", Token::Comment{ str: " a comment ".into(), contains_eof: false});
+	assert_tokens!("/*a comment*/", Token::Comment{ str: "a comment".into(), contains_eof: false});
+	assert_tokens!("/* <Ll#,;#l,_!\"^$!6 */", Token::Comment{ str: " <Ll#,;#l,_!\"^$!6 ".into(), contains_eof: false});
+	assert_tokens!("/* open-ended comment", Token::Comment{ str: " open-ended comment".into(), contains_eof: true});
+}
+
+#[test]
+#[rustfmt::skip]
 fn integers(){
 	// Zero
 	assert_tokens!("0", Token::Num{num: "0".into(), suffix: None, type_: NumType::Dec});

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -386,3 +386,114 @@ fn lexer(source: &str) -> Vec<Token> {
 
 	tokens
 }
+
+#[allow(unused_macros)]
+macro_rules! assert_tokens {
+    ($src:expr, $($token:expr),*) => {
+        assert_eq!(lexer($src), vec![
+            $(
+                $token,
+            )*
+        ])
+    };
+}
+
+#[test]
+fn identifiers() {
+	assert_tokens!("ident", Token::Ident("ident".into()));
+	assert_tokens!("gl_something", Token::Ident("gl_something".into()));
+	assert_tokens!("id_145", Token::Ident("id_145".into()));
+}
+
+#[test]
+fn keywords() {
+	assert_tokens!("if", Token::If);
+	assert_tokens!("else", Token::Else);
+	assert_tokens!("for", Token::For);
+	assert_tokens!("switch", Token::Switch);
+	assert_tokens!("case", Token::Case);
+	assert_tokens!("default", Token::Default);
+	assert_tokens!("break", Token::Break);
+	assert_tokens!("return", Token::Return);
+	assert_tokens!("discard", Token::Discard);
+	assert_tokens!("struct", Token::Struct);
+	assert_tokens!("in", Token::In);
+	assert_tokens!("out", Token::Out);
+	assert_tokens!("inout", Token::InOut);
+	assert_tokens!("uniform", Token::Uniform);
+	assert_tokens!("buffer", Token::Buffer);
+	assert_tokens!("const", Token::Const);
+	assert_tokens!("invariant", Token::Invariant);
+	assert_tokens!("highp", Token::Precision);
+	assert_tokens!("mediump", Token::Precision);
+	assert_tokens!("lowp", Token::Precision);
+	assert_tokens!("flat", Token::Interpolation);
+	assert_tokens!("smooth", Token::Interpolation);
+	assert_tokens!("noperspective", Token::Interpolation);
+	assert_tokens!("layout", Token::Layout);
+	assert_tokens!("location", Token::Location);
+	assert_tokens!("component", Token::Component);
+	assert_tokens!("origin_upper_left", Token::FragCoord);
+	assert_tokens!("pixel_center_integer", Token::FragCoord);
+	assert_tokens!("depth_any", Token::FragDepth);
+	assert_tokens!("depth_greater", Token::FragDepth);
+	assert_tokens!("depth_less", Token::FragDepth);
+	assert_tokens!("depth_unchanged", Token::FragDepth);
+	assert_tokens!("index", Token::Index);
+	assert_tokens!("early_fragment_test", Token::FragTest);
+}
+
+#[test]
+fn punctuation() {
+	assert_tokens!(";", Token::Semi);
+	assert_tokens!(".", Token::Dot);
+	assert_tokens!(",", Token::Comma);
+	assert_tokens!("=", Token::Eq);
+	assert_tokens!("(", Token::LParen);
+	assert_tokens!(")", Token::RParen);
+	assert_tokens!("[", Token::LBracket);
+	assert_tokens!("]", Token::RBracket);
+	assert_tokens!("{", Token::LBrace);
+	assert_tokens!("}", Token::RBrace);
+	assert_tokens!(":", Token::Colon);
+	assert_tokens!("+", Token::Op(OpType::Add));
+	assert_tokens!("-", Token::Op(OpType::Sub));
+	assert_tokens!("*", Token::Op(OpType::Mul));
+	assert_tokens!("/", Token::Op(OpType::Div));
+	assert_tokens!(">", Token::Op(OpType::Gt));
+	assert_tokens!("<", Token::Op(OpType::Lt));
+	assert_tokens!("!", Token::Op(OpType::Not));
+	assert_tokens!("~", Token::Op(OpType::Flip));
+	assert_tokens!("?", Token::Question);
+	assert_tokens!("%", Token::Op(OpType::Rem));
+	assert_tokens!("&", Token::Op(OpType::And));
+	assert_tokens!("|", Token::Op(OpType::Or));
+	assert_tokens!("^", Token::Op(OpType::Xor));
+	assert_tokens!("<<=", Token::Op(OpType::LShiftEq));
+	assert_tokens!(">>=", Token::Op(OpType::RShiftEq));
+	assert_tokens!("==", Token::Op(OpType::EqEq));
+	assert_tokens!("!=", Token::Op(OpType::NotEq));
+	assert_tokens!(">=", Token::Op(OpType::Le));
+	assert_tokens!("<=", Token::Op(OpType::Ge));
+	assert_tokens!("&&", Token::Op(OpType::AndAnd));
+	assert_tokens!("||", Token::Op(OpType::OrOr));
+	assert_tokens!("++", Token::Op(OpType::AddAdd));
+	assert_tokens!("--", Token::Op(OpType::SubSub));
+	assert_tokens!("<<", Token::Op(OpType::LShift));
+	assert_tokens!(">>", Token::Op(OpType::RShift));
+	assert_tokens!("+=", Token::Op(OpType::AddEq));
+	assert_tokens!("-=", Token::Op(OpType::SubEq));
+	assert_tokens!("*=", Token::Op(OpType::MulEq));
+	assert_tokens!("/=", Token::Op(OpType::DivEq));
+	assert_tokens!("%=", Token::Op(OpType::RemEq));
+	assert_tokens!("&=", Token::Op(OpType::AndEq));
+	assert_tokens!("|=", Token::Op(OpType::OrEq));
+	assert_tokens!("^^", Token::Op(OpType::XorXor));
+	assert_tokens!("^=", Token::Op(OpType::XorEq));
+}
+
+#[test]
+fn literals() {
+	assert_tokens!("true", Token::Bool(true));
+	assert_tokens!("false", Token::Bool(false));
+}

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1094,3 +1094,21 @@ fn floats() {
 	assert_tokens!(".1e+7lf", Token::Num{num: ".1e+7".into(), suffix: Some("lf".into()), type_: NumType::Float});
 	assert_tokens!(".1e-7lf", Token::Num{num: ".1e-7".into(), suffix: Some("lf".into()), type_: NumType::Float});
 }
+
+#[test]
+#[rustfmt::skip]
+fn directives(){
+	assert_tokens!("#directive", Token::Directive("directive".into()));
+	assert_tokens!("#   directive", Token::Directive("   directive".into()));
+	assert_tokens!("#directive args", Token::Directive("directive args".into()));
+	assert_tokens!("  #directive", Token::Directive("directive".into()));
+	assert_tokens!("\t#directive", Token::Directive("directive".into()));
+	assert_tokens!("#directive\\", Token::Directive("directive".into()));
+	assert_tokens!("#directive \\\\", Token::Directive("directive \\\\".into()));
+	assert_tokens!("#directive \\n", Token::Directive("directive \\n".into()));
+	assert_tokens!("#directive \\\r\n args", Token::Directive("directive \r\n args".into()));
+	assert_tokens!("#  directive \\\r args", Token::Directive("  directive \r args".into()));
+	assert_tokens!("#directive\\\nargs", Token::Directive("directive\nargs".into()));
+	assert_tokens!("#", Token::Directive("".into()));
+	assert_tokens!("   #", Token::Directive("".into()));
+}

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -237,8 +237,8 @@ fn match_punctuation(lexer: &mut Lexer) -> Token {
 	match_op!(lexer, ">>=", Token::Op(OpType::RShiftEq));
 	match_op!(lexer, "==", Token::Op(OpType::EqEq));
 	match_op!(lexer, "!=", Token::Op(OpType::NotEq));
-	match_op!(lexer, ">=", Token::Op(OpType::Le));
-	match_op!(lexer, "<=", Token::Op(OpType::Ge));
+	match_op!(lexer, ">=", Token::Op(OpType::Ge));
+	match_op!(lexer, "<=", Token::Op(OpType::Le));
 	match_op!(lexer, "&&", Token::Op(OpType::AndAnd));
 	match_op!(lexer, "||", Token::Op(OpType::OrOr));
 	match_op!(lexer, "++", Token::Op(OpType::AddAdd));
@@ -469,14 +469,13 @@ fn punctuation() {
 	assert_tokens!("&", Token::Op(OpType::And));
 	assert_tokens!("|", Token::Op(OpType::Or));
 	assert_tokens!("^", Token::Op(OpType::Xor));
-	assert_tokens!("<<=", Token::Op(OpType::LShiftEq));
-	assert_tokens!(">>=", Token::Op(OpType::RShiftEq));
 	assert_tokens!("==", Token::Op(OpType::EqEq));
 	assert_tokens!("!=", Token::Op(OpType::NotEq));
-	assert_tokens!(">=", Token::Op(OpType::Le));
-	assert_tokens!("<=", Token::Op(OpType::Ge));
+	assert_tokens!(">=", Token::Op(OpType::Ge));
+	assert_tokens!("<=", Token::Op(OpType::Le));
 	assert_tokens!("&&", Token::Op(OpType::AndAnd));
 	assert_tokens!("||", Token::Op(OpType::OrOr));
+	assert_tokens!("^^", Token::Op(OpType::XorXor));
 	assert_tokens!("++", Token::Op(OpType::AddAdd));
 	assert_tokens!("--", Token::Op(OpType::SubSub));
 	assert_tokens!("<<", Token::Op(OpType::LShift));
@@ -488,8 +487,9 @@ fn punctuation() {
 	assert_tokens!("%=", Token::Op(OpType::RemEq));
 	assert_tokens!("&=", Token::Op(OpType::AndEq));
 	assert_tokens!("|=", Token::Op(OpType::OrEq));
-	assert_tokens!("^^", Token::Op(OpType::XorXor));
 	assert_tokens!("^=", Token::Op(OpType::XorEq));
+	assert_tokens!("<<=", Token::Op(OpType::LShiftEq));
+	assert_tokens!(">>=", Token::Op(OpType::RShiftEq));
 }
 
 #[test]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -21,6 +21,9 @@ enum Token {
 	If,
 	Else,
 	For,
+	Do,
+	While,
+	Continue,
 	Switch,
 	Case,
 	Default,
@@ -28,6 +31,8 @@ enum Token {
 	Return,
 	Discard,
 	Struct,
+	Subroutine,
+	Reserved(String),
 	// Qualifiers
 	In,
 	Out,
@@ -297,6 +302,9 @@ fn match_word(str: String) -> Token {
 		"if" => Token::If,
 		"else" => Token::Else,
 		"for" => Token::For,
+		"do" => Token::Do,
+		"while" => Token::While,
+		"continue" => Token::Continue,
 		"switch" => Token::Switch,
 		"case" => Token::Case,
 		"default" => Token::Default,
@@ -304,6 +312,7 @@ fn match_word(str: String) -> Token {
 		"return" => Token::Return,
 		"discard" => Token::Discard,
 		"struct" => Token::Struct,
+		"subroutine" => Token::Subroutine,
 		// Qualifiers
 		"in" => Token::In,
 		"out" => Token::Out,
@@ -329,6 +338,16 @@ fn match_word(str: String) -> Token {
 		"depth_unchanged" => Token::FragDepth,
 		"index" => Token::Index,
 		"early_fragment_test" => Token::FragTest,
+		// Reserved
+		"common" | "partition" | "active" | "asm" | "class" | "union"
+		| "enum" | "typedef" | "template" | "this" | "resource" | "goto"
+		| "inline" | "noinline" | "public" | "static" | "extern"
+		| "external" | "interface" | "long" | "short" | "half" | "fixed"
+		| "unsigned" | "superp" | "input" | "output" | "hvec2" | "hvec3"
+		| "hvec4" | "fvec2" | "fvec3" | "fvec4" | "sampler3DRect"
+		| "filter" | "sizeof" | "cast" | "namespace" | "using" => {
+			Token::Reserved(str)
+		}
 		// Identifier
 		_ => Token::Ident(str),
 	}
@@ -886,6 +905,9 @@ fn keywords() {
 	assert_tokens!("if", Token::If);
 	assert_tokens!("else", Token::Else);
 	assert_tokens!("for", Token::For);
+	assert_tokens!("do", Token::Do);
+	assert_tokens!("while", Token::While);
+	assert_tokens!("continue", Token::Continue);
 	assert_tokens!("switch", Token::Switch);
 	assert_tokens!("case", Token::Case);
 	assert_tokens!("default", Token::Default);
@@ -893,6 +915,7 @@ fn keywords() {
 	assert_tokens!("return", Token::Return);
 	assert_tokens!("discard", Token::Discard);
 	assert_tokens!("struct", Token::Struct);
+	assert_tokens!("subroutine", Token::Subroutine);
 	assert_tokens!("in", Token::In);
 	assert_tokens!("out", Token::Out);
 	assert_tokens!("inout", Token::InOut);
@@ -917,6 +940,46 @@ fn keywords() {
 	assert_tokens!("depth_unchanged", Token::FragDepth);
 	assert_tokens!("index", Token::Index);
 	assert_tokens!("early_fragment_test", Token::FragTest);
+	// Reserved
+	assert_tokens!("common", Token::Reserved("common".into()));
+	assert_tokens!("partition", Token::Reserved("partition".into()));
+	assert_tokens!("active", Token::Reserved("active".into()));
+	assert_tokens!("asm", Token::Reserved("asm".into()));
+	assert_tokens!("class", Token::Reserved("class".into()));
+	assert_tokens!("union", Token::Reserved("union".into()));
+	assert_tokens!("enum", Token::Reserved("enum".into()));
+	assert_tokens!("typedef", Token::Reserved("typedef".into()));
+	assert_tokens!("template", Token::Reserved("template".into()));
+	assert_tokens!("this", Token::Reserved("this".into()));
+	assert_tokens!("resource", Token::Reserved("resource".into()));
+	assert_tokens!("goto", Token::Reserved("goto".into()));
+	assert_tokens!("inline", Token::Reserved("inline".into()));
+	assert_tokens!("noinline", Token::Reserved("noinline".into()));
+	assert_tokens!("public", Token::Reserved("public".into()));
+	assert_tokens!("static", Token::Reserved("static".into()));
+	assert_tokens!("extern", Token::Reserved("extern".into()));
+	assert_tokens!("external", Token::Reserved("external".into()));
+	assert_tokens!("interface", Token::Reserved("interface".into()));
+	assert_tokens!("long", Token::Reserved("long".into()));
+	assert_tokens!("short", Token::Reserved("short".into()));
+	assert_tokens!("half", Token::Reserved("half".into()));
+	assert_tokens!("fixed", Token::Reserved("fixed".into()));
+	assert_tokens!("unsigned", Token::Reserved("unsigned".into()));
+	assert_tokens!("superp", Token::Reserved("superp".into()));
+	assert_tokens!("input", Token::Reserved("input".into()));
+	assert_tokens!("output", Token::Reserved("output".into()));
+	assert_tokens!("hvec2", Token::Reserved("hvec2".into()));
+	assert_tokens!("hvec3", Token::Reserved("hvec3".into()));
+	assert_tokens!("hvec4", Token::Reserved("hvec4".into()));
+	assert_tokens!("fvec2", Token::Reserved("fvec2".into()));
+	assert_tokens!("fvec3", Token::Reserved("fvec3".into()));
+	assert_tokens!("fvec4", Token::Reserved("fvec4".into()));
+	assert_tokens!("sampler3DRect", Token::Reserved("sampler3DRect".into()));
+	assert_tokens!("filter", Token::Reserved("filter".into()));
+	assert_tokens!("sizeof", Token::Reserved("sizeof".into()));
+	assert_tokens!("cast", Token::Reserved("cast".into()));
+	assert_tokens!("namespace", Token::Reserved("namespace".into()));
+	assert_tokens!("using", Token::Reserved("using".into()));
 }
 
 #[test]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,0 +1,189 @@
+#![allow(unused)]
+
+/// Concrete syntax tree tokens.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Token {
+	Num {
+		num: String,
+		suffix: Option<String>,
+		base: NumBase,
+		type_: NumType,
+	},
+	Bool(bool),
+	Ident(String),
+	Directive(String),
+	Invalid(String),
+	// Keywords
+	If,
+	Else,
+	For,
+	Switch,
+	Case,
+	Default,
+	Break,
+	Return,
+	Discard,
+	Struct,
+	// Qualifiers
+	In,
+	Out,
+	InOut,
+	Uniform,
+	Buffer,
+	Const,
+	Invariant,
+	Interpolation,
+	Precision,
+	Layout,
+	Location,
+	Component,
+	FragCoord,
+	FragDepth,
+	Index,
+	FragTest,
+	// Punctuation
+	Op(OpType),
+	Eq,
+	Comma,
+	Dot,
+	Semi,
+	Colon,
+	Question,
+	LParen,
+	RParen,
+	LBracket,
+	RBracket,
+	LBrace,
+	RBrace,
+}
+
+/// Numerical bases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NumBase {
+	Oct,
+	Dec,
+	Hex,
+}
+
+/// Specifies distinction between integers and floating points.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NumType {
+	Int,
+	Float,
+}
+
+/// Mathematical and comparison operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpType {
+	// Maths
+	Add,
+	Sub,
+	Mul,
+	Div,
+	Rem,
+	And,
+	Or,
+	Xor,
+	LShift,
+	RShift,
+	AddEq,
+	SubEq,
+	MulEq,
+	DivEq,
+	RemEq,
+	AndEq,
+	OrEq,
+	XorEq,
+	LShiftEq,
+	RShiftEq,
+	AddAdd,
+	SubSub,
+	Flip,
+	// Comparison
+	EqEq,
+	NotEq,
+	Gt,
+	Lt,
+	Ge,
+	Le,
+	AndAnd,
+	OrOr,
+	XorXor,
+	Not,
+}
+
+/// A lexer which allows stepping through a string character by character.
+struct Lexer {
+	/// The string stored as a vector of characters.
+	chars: Vec<char>,
+	/// The index of the current character.
+	cursor: usize,
+}
+
+impl Lexer {
+	/// Constructs a new `Lexer` from the given source string.
+	fn new(source: &str) -> Self {
+		Self {
+			chars: source.chars().collect(),
+			cursor: 0,
+		}
+	}
+
+	/// Returns the current character under the cursor, without advancing the cursor.
+	fn peek(&self) -> Option<char> {
+		self.chars.get(self.cursor).map(|c| *c)
+	}
+
+	/// Peeks the next character without advancing the cursor; (returns the character under `cursor + 1`).
+	fn lookahead_1(&self) -> Option<char> {
+		self.chars.get(self.cursor + 1).map(|c| *c)
+	}
+
+	/// Advances the cursor by one.
+	fn advance(&mut self) {
+		self.cursor += 1;
+	}
+
+	/// Returns the current character under the cursor and advances the cursor by one.
+	fn next(&mut self) -> Option<char> {
+		// If we are successful in getting the character, advance the cursor.
+		match self.chars.get(self.cursor) {
+			Some(c) => {
+				self.cursor += 1;
+				Some(*c)
+			}
+			None => None,
+		}
+	}
+
+	/// Tries to match a pattern starting at the current character under the cursor. If the match is successful,
+	/// `true` is returned and the cursor is advanced to consume the pattern. If the match is unsuccessful, `false`
+	/// is returned and the cursor stays in place.
+	fn take_pat(&mut self, pat: &str) -> bool {
+		let len = pat.len();
+
+		// If the pattern fits within the remaining length of the character string, compare.
+		if self.chars.len() >= self.cursor + len {
+			let res = self.chars[self.cursor..self.cursor + len]
+				.iter()
+				.zip(pat.chars())
+				.all(|(c, p)| *c == p);
+
+			// If the match was successful, advance the cursor.
+			if res {
+				self.cursor += len;
+			}
+
+			return res;
+		}
+
+		false
+	}
+
+	/// Returns whether the `Lexer` has reached the end of the source string.
+	fn is_done(&self) -> bool {
+		// We check that the cursor is equal to the length, because that means we have gone past the last character
+		// of the string, and hence, we are done.
+		self.cursor == self.chars.len()
+	}
+}

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -375,6 +375,12 @@ fn lexer(source: &str) -> Vec<Token> {
 					break 'word;
 				}
 			}
+		} else if is_punctuation_start(&current) {
+			tokens.push(match_punctuation(&mut lexer));
+		} else {
+			// We don't care about this character.
+			// TODO: Create invalid tokens.
+			lexer.advance()
 		}
 	}
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,8 +1,9 @@
 #![allow(unused)]
+// Note: The `Hash` derives are only needed because of the chumsky parser.
 
 /// Concrete syntax tree tokens.
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum Token {
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Token {
 	Num {
 		num: String,
 		suffix: Option<String>,
@@ -67,7 +68,7 @@ enum Token {
 }
 
 /// The different number types/notations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum NumType {
 	Dec,
 	Oct,
@@ -76,7 +77,7 @@ pub enum NumType {
 }
 
 /// Mathematical and comparison operators.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum OpType {
 	// Maths
 	Add,
@@ -115,7 +116,7 @@ pub enum OpType {
 	Not,
 }
 
-type Spanned<T> = (T, std::ops::Range<usize>);
+pub type Spanned<T> = (T, std::ops::Range<usize>);
 
 /// A lexer which allows stepping through a string character by character.
 struct Lexer {
@@ -434,7 +435,7 @@ enum NumState {
 }
 
 /// Performs lexical analysis of the source string and returns a vector of [`Token`]s.
-fn lexer(source: &str) -> Vec<Spanned<Token>> {
+pub fn lexer(source: &str) -> Vec<Spanned<Token>> {
 	let mut tokens = Vec::new();
 	let mut lexer = Lexer::new(source);
 	let mut buffer_start: usize = 0;

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1118,3 +1118,19 @@ fn directives(){
 	assert_tokens!("#", Token::Directive("".into()));
 	assert_tokens!("   #", Token::Directive("".into()));
 }
+
+#[test]
+#[rustfmt::skip]
+fn illegal(){
+	// Note: All of these characters will be parsed as part of a preprocessor directive string; only later once the
+	// string is tokenised will any errors come up.
+	assert_tokens!("@", Token::Invalid('@'));
+	assert_tokens!("¬", Token::Invalid('¬'));
+	assert_tokens!("`", Token::Invalid('`'));
+	assert_tokens!("¦", Token::Invalid('¦'));
+	assert_tokens!("'", Token::Invalid('\''));
+	assert_tokens!("\"", Token::Invalid('"'));
+	assert_tokens!("£", Token::Invalid('£'));
+	assert_tokens!("$", Token::Invalid('$'));
+	assert_tokens!("€", Token::Invalid('€'));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use std::{
 pub mod ast;
 pub mod parser;
 pub mod shader;
+pub mod lexer;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Type {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,27 +1,23 @@
 use crate::ast::{
 	Either, Expr, ExtBehaviour, Ident, Lit, Preproc, Primitive, Stmt, Type,
 };
+use crate::lexer::{lexer, NumType, OpType, Token};
 use chumsky::{prelude::*, Stream};
 
 pub fn parse(source: &str) {
-	let (cst, errors) = lexer().parse_recovery(source);
+	let cst = lexer(source);
 	println!("{cst:?}");
-	println!("errors: {errors:?}");
 
-	if let Some(tokens) = cst {
-		let len = source.chars().count();
-		let (ast, errors) = parser().parse_recovery(Stream::from_iter(
-			len..len + 1,
-			tokens.into_iter(),
-		));
-		println!("{ast:?}");
-		if let Some(ast) = ast {
-			for stmt in ast {
-				print_stmt(&stmt, 0);
-			}
+	let len = source.chars().count();
+	let (ast, errors) = parser()
+		.parse_recovery(Stream::from_iter(len..len + 1, cst.into_iter()));
+	println!("{ast:?}");
+	if let Some(ast) = ast {
+		for stmt in ast {
+			print_stmt(&stmt, 0);
 		}
-		println!("\r\nerrors: {errors:?}");
 	}
+	println!("\r\nerrors: {errors:?}");
 }
 
 fn print_stmt(stmt: &Stmt, indent: usize) {
@@ -269,505 +265,6 @@ macro_rules! binary_expr {
 	};
 }
 
-/// Concrete syntax tree tokens.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum Token {
-	Num(String, NumType),
-	Bool(bool),
-	Ident(String),
-	Directive(String),
-	Invalid(String),
-	// Keywords
-	If,
-	Else,
-	For,
-	Switch,
-	Case,
-	Default,
-	Break,
-	Return,
-	Discard,
-	Struct,
-	// Qualifiers
-	In,
-	Out,
-	InOut,
-	Uniform,
-	Buffer,
-	Const,
-	Invariant,
-	Interpolation,
-	Precision,
-	Layout,
-	Location,
-	Component,
-	FragCoord,
-	FragDepth,
-	Index,
-	FragTest,
-	// Punctuation
-	Op(OpType),
-	Eq,
-	Comma,
-	Dot,
-	Semi,
-	Colon,
-	Question,
-	LParen,
-	RParen,
-	LBracket,
-	RBracket,
-	LBrace,
-	RBrace,
-}
-
-/// The different number types/notations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum NumType {
-	Normal,
-	Oct,
-	Hex,
-	Float,
-	Double,
-}
-
-/// Mathematical and comparison operators.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum OpType {
-	// Maths
-	Add,
-	Sub,
-	Mul,
-	Div,
-	Rem,
-	And,
-	Or,
-	Xor,
-	LShift,
-	RShift,
-	AddEq,
-	SubEq,
-	MulEq,
-	DivEq,
-	RemEq,
-	AndEq,
-	OrEq,
-	XorEq,
-	LShiftEq,
-	RShiftEq,
-	AddAdd,
-	SubSub,
-	Flip,
-	// Comparison
-	EqEq,
-	NotEq,
-	Gt,
-	Lt,
-	Ge,
-	Le,
-	AndAnd,
-	OrOr,
-	XorXor,
-	Not,
-}
-
-type Spanned<T> = (T, Span);
-type Span = std::ops::Range<usize>;
-
-/// Performs lexical parsing of the steam of `char`s into a list of [`Token`]s with their span in the string.
-fn lexer() -> impl Parser<char, Vec<Spanned<Token>>, Error = Simple<char>> {
-	// Preprocessor directive lines must be parsed first and as a whole string. This must be done because unlike
-	// with statements, where the 'parser()' is looking for a series of tokens followed a semi-colon, directives
-	// have no semi-colon and instead their end is categorised by the EOL. By parsing the entire directive line
-	// into a single string, we simplify this parser and reduce the number of edge cases we need to track.
-	// Meanwhile, the directive can be parsed on its own in the 'preproc_parser()' function.
-	let directive = just('#')
-		.then(
-			filter(|c: &char| {
-				// TODO: Check which characters are actually valid within a preprocessor directive.
-				c.is_ascii_alphanumeric()
-					|| c.is_ascii_punctuation()
-					|| *c == ' '
-			})
-			.repeated()
-			.at_least(1),
-		)
-		.then_ignore(text::newline().or(end()))
-		.map(|(_, v)| Token::Directive(v.iter().collect()))
-		.padded();
-
-	// Parse the source code in order of least ambiguity, to ensure the correct tokens are given out every time.
-	let token = literals()
-		.or(punctuation())
-		.or(keywords())
-		.or(text::ident().map(|s| Token::Ident(s)))
-		// If none of the patterns have succeeded, then we must have a character that is straight up illegal in
-		// glsl source code (or a situation where a character is legal but can't start the token with it, e.g.
-		// '_'), so create an 'Invalid' token.
-		.or(filter(|_| true).map(|c| Token::Invalid(String::from(c))))
-		.padded();
-
-	directive
-		.or(token)
-		.map_with_span(|t, s| (t, s))
-		.repeated()
-		.recover_with(skip_then_retry_until([]))
-}
-
-/// Parse any valid punctuation or operator symbols.
-fn punctuation() -> impl Parser<char, Token, Error = Simple<char>> {
-	// Parse in order of least ambiguity, so starting with 3 characters and going to 1, and most common occurrence,
-	// to reduce the average amount of checks necessary.
-	//
-	// Split because of limit; 'choice()' is a generic function for performance reasons and it only has 26 generic
-	// overrides.
-	choice((
-		just("<<=").to(Token::Op(OpType::LShiftEq)),
-		just(">>=").to(Token::Op(OpType::RShiftEq)),
-		just("==").to(Token::Op(OpType::EqEq)),
-		just("!=").to(Token::Op(OpType::NotEq)),
-		just(">=").to(Token::Op(OpType::Ge)),
-		just("<=").to(Token::Op(OpType::Le)),
-		just("&&").to(Token::Op(OpType::AndAnd)),
-		just("||").to(Token::Op(OpType::OrOr)),
-		just("++").to(Token::Op(OpType::AddAdd)),
-		just("--").to(Token::Op(OpType::SubSub)),
-		just("<<").to(Token::Op(OpType::LShift)),
-		just(">>").to(Token::Op(OpType::RShift)),
-		just("+=").to(Token::Op(OpType::AddEq)),
-		just("-=").to(Token::Op(OpType::SubEq)),
-		just("*=").to(Token::Op(OpType::MulEq)),
-		just("/=").to(Token::Op(OpType::DivEq)),
-		just("%=").to(Token::Op(OpType::RemEq)),
-		just("&=").to(Token::Op(OpType::AndEq)),
-		just("|=").to(Token::Op(OpType::OrEq)),
-		just("^^").to(Token::Op(OpType::XorXor)),
-		just("^=").to(Token::Op(OpType::XorEq)),
-	))
-	.or(choice((
-		just('=').to(Token::Eq),
-		just(',').to(Token::Comma),
-		just('.').to(Token::Dot),
-		just(';').to(Token::Semi),
-		just('(').to(Token::LParen),
-		just(')').to(Token::RParen),
-		just('[').to(Token::LBracket),
-		just(']').to(Token::RBracket),
-		just('{').to(Token::LBrace),
-		just('}').to(Token::RBrace),
-		just(':').to(Token::Colon),
-		just('+').to(Token::Op(OpType::Add)),
-		just('-').to(Token::Op(OpType::Sub)),
-		just('*').to(Token::Op(OpType::Mul)),
-		just('/').to(Token::Op(OpType::Div)),
-		just('>').to(Token::Op(OpType::Gt)),
-		just('<').to(Token::Op(OpType::Lt)),
-		just('!').to(Token::Op(OpType::Not)),
-		just('~').to(Token::Op(OpType::Flip)),
-		just('?').to(Token::Question),
-		just('%').to(Token::Op(OpType::Rem)),
-		just('&').to(Token::Op(OpType::And)),
-		just('|').to(Token::Op(OpType::Or)),
-		just('^').to(Token::Op(OpType::Xor)),
-	)))
-}
-
-/// Parse keywords.
-fn keywords() -> impl Parser<char, Token, Error = Simple<char>> {
-	// Split because of limit; 'choice()' is a generic function for performance reasons and it only has 26 generic
-	// overrides.
-	choice((
-		text::keyword("if").to(Token::If),
-		text::keyword("else").to(Token::Else),
-		text::keyword("for").to(Token::For),
-		text::keyword("switch").to(Token::Switch),
-		text::keyword("case").to(Token::Case),
-		text::keyword("default").to(Token::Default),
-		text::keyword("break").to(Token::Break),
-		text::keyword("return").to(Token::Return),
-		text::keyword("discard").to(Token::Discard),
-		text::keyword("struct").to(Token::Struct),
-		// TODO: Parse reserved keywords which have no use currently.
-	))
-	.or(choice((
-		text::keyword("in").to(Token::In),
-		text::keyword("out").to(Token::Out),
-		text::keyword("inout").to(Token::InOut),
-		text::keyword("uniform").to(Token::Uniform),
-		text::keyword("buffer").to(Token::Buffer),
-		text::keyword("const").to(Token::Const),
-		text::keyword("invariant").to(Token::Invariant),
-		text::keyword("highp").to(Token::Precision),
-		text::keyword("mediump").to(Token::Precision),
-		text::keyword("lowp").to(Token::Precision),
-		text::keyword("flat").to(Token::Interpolation),
-		text::keyword("smooth").to(Token::Interpolation),
-		text::keyword("noperspective").to(Token::Interpolation),
-		text::keyword("layout").to(Token::Layout),
-		text::keyword("location").to(Token::Location),
-		text::keyword("component").to(Token::Component),
-		text::keyword("origin_upper_left").to(Token::FragCoord),
-		text::keyword("pixel_center_integer").to(Token::FragCoord),
-		text::keyword("depth_any").to(Token::FragDepth),
-		text::keyword("depth_greater").to(Token::FragDepth),
-		text::keyword("depth_less").to(Token::FragDepth),
-		text::keyword("depth_unchanged").to(Token::FragDepth),
-		text::keyword("index").to(Token::Index),
-		text::keyword("early_fragment_tests").to(Token::FragTest),
-	)))
-}
-
-/// Parse literal values, i.e. numbers and booleans.
-///
-/// If this parser encounters a partially valid number, where the first *n* characters are valid but the last *m*
-/// are not, it will return a [`Token::Invalid`]. This is done because of the following reason:
-///
-/// For every token other than number literals, spaces don't matter, i.e. `i+=5` will be parsed as a
-/// `[Token::Ident("i"), Token::AddEq, Token::Num(5)]`. However, because numbers *can* contain ascii letters at the
-/// end (such as the `u` postfix), this creates an element of ambiguity. Take for example the string `5.0ufoo`.
-/// According to the glsl spec, this string is seen as a float of value `5.0` with a postfix of `ufoo` (which is an
-/// invalid postfix). If this literal parser only cared about valid patterns, the `lexer()` would produce
-/// `[Token::Num(5, NumType::Float), Token::Ident("ufoo")]`, which is clearly incorrect, because after a number we
-/// need padding **if** the next token is an identifier (we don't need padding for punctuation). So instead, by
-/// also matching for invalid characters after a number, we can produce a `Token::Invalid("5.0ufoo")` which is the
-/// corrent result.
-///
-/// You may think that an alternative like this would work:
-/// ```
-/// num_float
-///     .or(num_double)
-///     /*...*/
-///     .then_ignore(filter(|c: &char| *c == ' '))
-/// ```
-/// But it doesn't. This wouldn't parse `5+` because of the missing space between the number and operator. The key
-/// isn't that we want a space after a number. It's that we want a space if the characters (after any valid
-/// postfix) are letters.
-fn literals() -> impl Parser<char, Token, Error = Simple<char>> {
-	// Unsigned integer suffix.
-	let suffix = filter(|c: &char| *c == 'u' || *c == 'U').or_not();
-	// Double specifier suffix.
-	let lf = just('l').then(just('f')).or(just('L').then(just('F')));
-
-	let zero_valid = just('0')
-		.chain::<char, _, _>(suffix)
-		.collect::<String>()
-		.map(|s| Token::Num(s, NumType::Normal));
-	let zero_invalid = just('0')
-		.chain::<char, _, _>(suffix)
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_alphanumeric())
-				.repeated()
-				.at_least(1),
-		)
-		.collect::<String>()
-		.map(|s| Token::Invalid(s));
-
-	let num = filter(|c: &char| c.is_ascii_digit() && *c != '0')
-		.chain::<char, _, _>(filter(|c: &char| c.is_ascii_digit()).repeated())
-		.chain::<char, _, _>(suffix);
-	let num_valid = num.collect().map(|s| Token::Num(s, NumType::Normal));
-	let num_invalid = num
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_alphanumeric())
-				.repeated()
-				.at_least(1),
-		)
-		.collect::<String>()
-		.map(|s| Token::Invalid(s));
-
-	let num_hex = just('0')
-		.then(just('x'))
-		.chain::<char, _, _>(
-			filter::<_, _, Simple<char>>(|c: &char| c.is_ascii_hexdigit())
-				.repeated()
-				.at_least(1),
-		)
-		.chain::<char, _, _>(suffix);
-	let num_hex_valid = num_hex.collect().map(|s| Token::Num(s, NumType::Hex));
-	let num_hex_invalid = num_hex
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_alphanumeric())
-				.repeated()
-				.at_least(1),
-		)
-		.collect::<String>()
-		.map(|s| Token::Invalid(s));
-
-	let num_oct = just('0')
-		.chain::<char, _, _>(
-			filter(|c: &char| match c {
-				'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' => true,
-				_ => false,
-			})
-			.repeated()
-			.at_least(1),
-		)
-		.chain::<char, _, _>(suffix);
-	let num_oct_valid = num_oct.collect().map(|s| Token::Num(s, NumType::Oct));
-	let num_oct_invalid = num_oct
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_alphanumeric())
-				.repeated()
-				.at_least(1),
-		)
-		.collect::<String>()
-		.map(|s| Token::Invalid(s));
-
-	let num_float = filter(|c: &char| c.is_ascii_digit())
-		.repeated()
-		.at_least(1)
-		.chain(just('.'))
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_digit()).repeated().at_least(1),
-		);
-	let num_float_valid = num_float
-		.collect::<String>()
-		.map(|s| Token::Num(s, NumType::Float));
-	let num_float_invalid = num_float
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_alphanumeric())
-				.repeated()
-				.at_least(1),
-		)
-		.collect::<String>()
-		.map(|s| Token::Invalid(s));
-
-	let num_float_exp = filter(|c: &char| c.is_ascii_digit())
-		.repeated()
-		.at_least(1)
-		.chain(just('.'))
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_digit()).repeated().at_least(1),
-		)
-		.chain(just('E').or(just('e')))
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_digit()).repeated().at_least(1),
-		);
-	let num_float_exp_valid = num_float_exp
-		.collect::<String>()
-		.map(|s| Token::Num(s, NumType::Float));
-	let num_float_exp_invalid = num_float_exp
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_alphanumeric())
-				.repeated()
-				.at_least(1),
-		)
-		.collect::<String>()
-		.map(|s| Token::Invalid(s));
-
-	let num_float_exp_no_decimal = filter(|c: &char| c.is_ascii_digit())
-		.repeated()
-		.at_least(1)
-		.chain(just('E').or(just('e')))
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_digit()).repeated().at_least(1),
-		);
-	let num_float_exp_no_decimal_valid = num_float_exp_no_decimal
-		.collect::<String>()
-		.map(|s| Token::Num(s, NumType::Float));
-	let num_float_exp_no_decimal_invalid = num_float_exp_no_decimal
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_alphanumeric())
-				.repeated()
-				.at_least(1),
-		)
-		.collect::<String>()
-		.map(|s| Token::Invalid(s));
-
-	let num_double = filter(|c: &char| c.is_ascii_digit())
-		.repeated()
-		.at_least(1)
-		.chain(just('.'))
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_digit()).repeated().at_least(1),
-		)
-		.chain::<char, _, _>(lf);
-	let num_double_valid = num_double
-		.collect::<String>()
-		.map(|s| Token::Num(s, NumType::Double));
-	let num_double_invalid = num_double
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_alphanumeric())
-				.repeated()
-				.at_least(1),
-		)
-		.collect::<String>()
-		.map(|s| Token::Invalid(s));
-
-	let num_double_exp = filter(|c: &char| c.is_ascii_digit())
-		.repeated()
-		.at_least(1)
-		.chain(just('.'))
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_digit()).repeated().at_least(1),
-		)
-		.chain(just('E').or(just('e')))
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_digit()).repeated().at_least(1),
-		)
-		.chain::<char, _, _>(lf);
-	let num_double_exp_valid = num_double_exp
-		.collect::<String>()
-		.map(|s| Token::Num(s, NumType::Double));
-	let num_double_exp_invalid = num_double_exp
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_alphanumeric())
-				.repeated()
-				.at_least(1),
-		)
-		.collect::<String>()
-		.map(|s| Token::Invalid(s));
-
-	let num_double_exp_no_decimal = filter(|c: &char| c.is_ascii_digit())
-		.repeated()
-		.at_least(1)
-		.chain(just('E').or(just('e')))
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_digit()).repeated().at_least(1),
-		)
-		.chain::<char, _, _>(lf);
-	let num_double_exp_no_decimal_valid = num_double_exp_no_decimal
-		.collect::<String>()
-		.map(|s| Token::Num(s, NumType::Double));
-	let num_double_exp_no_decimal_invalid = num_double_exp_no_decimal
-		.chain::<char, _, _>(
-			filter(|c: &char| c.is_ascii_alphanumeric())
-				.repeated()
-				.at_least(1),
-		)
-		.collect::<String>()
-		.map(|s| Token::Invalid(s));
-
-	// Unlike with the number parsers, we don't need to check for characters after the boolean, i.e. 'truep'
-	// because the 'text::keyword()' function already makes sure that the string is not followed by any other
-	// letters (still allows punctuation, etc.).
-	let b_true = text::keyword("true").map(|_| Token::Bool(true));
-	let b_false = text::keyword("false").map(|_| Token::Bool(false));
-
-	num_hex_invalid
-		.or(num_hex_valid)
-		.or(num_oct_invalid)
-		.or(num_oct_valid)
-		.or(num_double_exp_invalid)
-		.or(num_double_exp_valid)
-		.or(num_double_exp_no_decimal_invalid)
-		.or(num_double_exp_no_decimal_valid)
-		.or(num_double_invalid)
-		.or(num_double_valid)
-		.or(num_float_exp_invalid)
-		.or(num_float_exp_valid)
-		.or(num_float_exp_no_decimal_invalid)
-		.or(num_float_exp_no_decimal_valid)
-		.or(num_float_invalid)
-		.or(num_float_valid)
-		.or(num_invalid)
-		.or(num_valid)
-		.or(zero_invalid)
-		.or(zero_valid)
-		.or(b_true)
-		.or(b_false)
-}
-
 fn parser() -> impl Parser<Token, Vec<Stmt>, Error = Simple<Token>> {
 	// Identifier for a name.
 	let ident = filter(|t: &Token| match t {
@@ -839,14 +336,18 @@ fn parser() -> impl Parser<Token, Vec<Stmt>, Error = Simple<Token>> {
 	// Array size, i.e. `[...]`.
 	let arr = {
 		let size = filter(|t: &Token| match t {
-			Token::Num(_, _) => true,
+			Token::Num { .. } => true,
 			Token::Ident(_) => true,
 			_ => false,
 		})
 		.try_map(|t, span| match t {
-			Token::Num(s, t) => match t {
-				NumType::Normal | NumType::Oct | NumType::Hex => {
-					match Lit::parse_num(&s, t) {
+			Token::Num {
+				num: s,
+				suffix,
+				type_,
+			} => match type_ {
+				NumType::Dec | NumType::Oct | NumType::Hex => {
+					match Lit::parse_num(&s, suffix.as_deref(), type_) {
 						Ok(l) => match l {
 							Lit::UInt(u) => Ok(Either::Left(u as usize)),
 							Lit::Int(i) => Ok(Either::Left(i as usize)),
@@ -958,13 +459,17 @@ fn parser() -> impl Parser<Token, Vec<Stmt>, Error = Simple<Token>> {
 
 		let val = member.or(filter(|t: &Token| match t {
 			Token::Bool(_) => true,
-			Token::Num(_, _) => true,
+			Token::Num { .. } => true,
 			Token::Ident(_) => true,
 			_ => false,
 		})
 		.try_map(|t, span| match t {
 			Token::Bool(b) => Ok(Expr::Lit(Lit::Bool(b))),
-			Token::Num(s, t) => match Lit::parse_num(&s, t) {
+			Token::Num {
+				num: s,
+				suffix,
+				type_,
+			} => match Lit::parse_num(&s, suffix.as_deref(), type_) {
 				Ok(l) => Ok(Expr::Lit(l)),
 				Err(_) => Err(Simple::custom(span, "Could not parse number")),
 			},


### PR DESCRIPTION
Replace the current `chumsky` lexer with a handwritten lexer.

This is done for the following reasons:
- The existing lexer, especially the number-parsing logic was getting extremely long and with many many branches. The rewrite has *much* less branching and supports more valid notations.
- The preprocessor parsing was only half functional, and it didn't deal with newline escapes. This was something that'd be difficult to implement. I was running into numerous cases where chumsky didn't like the ambiguity of the patterns, and the rewrite fixes this.